### PR TITLE
Temporary Fixed cannot be delete xxx/classes.jar

### DIFF
--- a/stop_gradle.bat
+++ b/stop_gradle.bat
@@ -1,0 +1,1 @@
+gradlew --stop


### PR DESCRIPTION
在 Win 平台上子组件集成测试时经常会抛出不能删除 jar 包异常
```ruby
java.lang.RuntimeException: java.io.IOException: Failed to delete xxx\build\intermediates\intermediate-jars\debug\classes.jar
```
临时解决这个问题，只需要在 Terminal 终端内运行 gradle_stop.bat

