### PR TITLE
AutowiredServiceImpl类里加了一个catch，防止logcat无意义的打印

### DIFF
--- a/componentlib/src/main/java/com/luojilab/component/componentlib/service/AutowiredServiceImpl.java
+++ b/componentlib/src/main/java/com/luojilab/component/componentlib/service/AutowiredServiceImpl.java
@@ -45,6 +45,9 @@ public class AutowiredServiceImpl implements AutowiredService {
             } else {
                 ILogger.logger.monitor("[autowire] " + className + "is in blacklist, ignore data inject");
             }
+        } catch (ClassNotFoundException e) {
+            //ignore
+            blackList.add(className);  // This instance don't need autowired.
         } catch (Exception ex) {
             if (ex instanceof NullPointerException) { // may define custom exception better
                 throw new NullPointerException(ex.getMessage());


### PR DESCRIPTION
在BaseActivity添加AutowiredService.Factory.getInstance().create().autowire(this)以后，如果这个类或者子类的字段并没有添加Autowired注解的话，在AutowiredServiceImpl里执行Class.forName会有ClassNotFoundException，这是因为这个类或者子类没有被Autowired注解的字段所以对应的Autowired类没有生成导致的，所以这里加一个catch防止Logcat无意义的打印