### PR TITLE
增加更多的命令做匹配

### DIFF
--- a/build-gradle/src/main/groovy/com.dd.buildgradle/ComBuild.groovy
+++ b/build-gradle/src/main/groovy/com.dd.buildgradle/ComBuild.groovy
@@ -97,6 +97,8 @@ class ComBuild implements Plugin<Project> {
         for (String task : taskNames) {
             if (task.toUpperCase().contains("ASSEMBLE")
                     || task.contains("aR")
+                    || task.contains("asR")
+                    || task.contains("asD")
                     || task.toUpperCase().contains("TINKER")
                     || task.toUpperCase().contains("INSTALL")
                     || task.toUpperCase().contains("RESGUARD")) {


### PR DESCRIPTION
一般使用aR时会跟出现冲突,有时候会使用asR或者asD,不过这个时候没有匹配到编译命令导致编译失败.这个问题困扰我好久.