### PR TITLE
将core工程适配到gradle 4.6+

### DIFF
--- a/jimu-core/build-gradle/build.gradle
+++ b/jimu-core/build-gradle/build.gradle
@@ -21,7 +21,7 @@ apply from: '../installv1.gradle'
 apply from: '../bintrayv1.gradle'
 
 dependencies {
-    compile 'com.android.tools.build:gradle:2.3.2'
+    compile deps.android.gradlePlugin
     compile group: 'org.javassist', name: 'javassist', version: '3.23.1-GA'
     //gradle sdk
     compile gradleApi()

--- a/jimu-core/build.gradle
+++ b/jimu-core/build.gradle
@@ -4,10 +4,10 @@ buildscript {
             'minSdk'        : 14,
             'targetSdk'     : 21,
             'compileSdk'    : 27,
-            'kotlin'        : '1.2.30',
+            'kotlin'        : '1.2.51',
             'supportLibrary': '27.0.2',
-            'androidPlugin' : '2.3.1',
-            'androidTools'  : '27.0.3',
+            'androidPlugin' : '3.2.1',
+            'androidTools'  : '28.0.3',
     ]
 
     ext.deps = [
@@ -52,7 +52,7 @@ buildscript {
 
             publish  : [
                     'jcenter': 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.2',
-                    'maven'  : 'com.github.dcendents:android-maven-gradle-plugin:1.5',
+                    'maven'  : 'com.github.dcendents:android-maven-gradle-plugin:2.1',
             ],
 
             jimu     : [

--- a/jimu-core/componentlib/build.gradle
+++ b/jimu-core/componentlib/build.gradle
@@ -47,23 +47,23 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    testCompile deps.junit
-    compile deps.support.v7.appcompat
+    testImplementation deps.junit
+    implementation deps.support.v7.appcompat
 
-//    compile project(':router-annotation')
-    compile deps.jimu.router_anno
-    compile deps.gson
+//    implementation project(':router-annotation')
+    implementation deps.jimu.router_anno
+    implementation deps.gson
 
-    compile deps.report.anno
+    implementation deps.report.anno
     annotationProcessor deps.report.compiler
 
 
-    compile 'org.apache.commons:commons-lang3:3.4'
-    compile 'org.apache.commons:commons-collections4:4.1'
+    implementation 'org.apache.commons:commons-lang3:3.4'
+    implementation 'org.apache.commons:commons-collections4:4.1'
 }
 
 


### PR DESCRIPTION
因为目前大家都在使用 `gradle 4.6+` 和 `com.android.tools.build:gradle:3.2.1` 进行开发，所以对`jimu-core`中的`kotlin`等进行了版本升级。
```
kotlin -> 1.2.51
androidPlugin -> 3.2.1
androidTools -> 28.0.3
android-maven-gradle-plugin -> 2.1
```
接下来还需要发布新版本的库，并更新`jimu-sample-project`